### PR TITLE
Add German DHL module and custom tracking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
     "authors": [{
         "name" : "Karliuka Vitalii",
         "email": "karliuka.vitalii@gmail.com"
+    },
+	{
+        "name" : "Marcus Wolschon",
+        "email": "Marcus@Wolschon.biz"
     }],		
 	"license": [
 		"OSL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,6 +14,12 @@
 			<resource>Faonni_TrackingLink::tracking</resource>
             <group id="service_url" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Tracking Service Url</label>
+                <field id="dhlshipping" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>DHL Versenden</label>
+                </field>
+                <field id="custom" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Custom</label>
+                </field>
                 <field id="dhl" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>DHL</label>
                 </field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,7 +11,7 @@
     <default>
         <faonni_tracking>
             <service_url>
-			    <custom><![CDATA[https://www.myhermes.de/empfangen/sendungsverfolgung/?suche={{number}}]]></dhlshipping>
+			    <custom><![CDATA[https://www.myhermes.de/empfangen/sendungsverfolgung/?suche={{number}}]]></custom>
                 <dhlshipping><![CDATA[https://www.dhl.de/de/privatkunden.html?piececode={{number}}]]></dhlshipping>
                 <dhl><![CDATA[http://webtrack.dhlglobalmail.com/?trackingnumber={{number}}]]></dhl>
                 <fedex><![CDATA[https://www.fedex.com/apps/fedextrack/?action=track&action=track&tracknumbers={{number}}]]></fedex>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,8 @@
     <default>
         <faonni_tracking>
             <service_url>
+			    <custom><![CDATA[https://www.myhermes.de/empfangen/sendungsverfolgung/?suche={{number}}]]></dhlshipping>
+                <dhlshipping><![CDATA[https://www.dhl.de/de/privatkunden.html?piececode={{number}}]]></dhlshipping>
                 <dhl><![CDATA[http://webtrack.dhlglobalmail.com/?trackingnumber={{number}}]]></dhl>
                 <fedex><![CDATA[https://www.fedex.com/apps/fedextrack/?action=track&action=track&tracknumbers={{number}}]]></fedex>
                 <ups><![CDATA[https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums={{number}}]]></ups>

--- a/i18n/de_DE.csv
+++ b/i18n/de_DE.csv
@@ -1,0 +1,1 @@
+"Tracking Url","Sendungsverfolgung"


### PR DESCRIPTION
Add "dhlshipping" used by the official German DHL module in addition to international DHL Express.
Add the option of a tracking URL for "custom".
Add a German translation.